### PR TITLE
Pass request headers to resource objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ finch_client = Finch::Client::API.new(access_token)
 
 Keep in mind that this client instance is scoped only to the provided access token. You'll need to create a new client if you want to work with a different access token.
 
-From here, you're set to use any of the Finch APIs listed below!
+From here, you're set to use any of the Finch APIs listed below! All objects returned from API calls respond to `.headers` if you need to access the raw Finch headers.
 
 ### Organization APIs
 

--- a/lib/finch/client.rb
+++ b/lib/finch/client.rb
@@ -5,6 +5,7 @@ require 'finch/client/version'
 require 'finch/client/connect'
 require 'finch/client/resource'
 require 'finch/client/configuration'
+require 'finch/client/resource_collection'
 
 module Finch
   module Client

--- a/lib/finch/client/api/connection.rb
+++ b/lib/finch/client/api/connection.rb
@@ -3,7 +3,14 @@
 module Finch
   module Client
     class API
-      class APIError < StandardError; end
+      class APIError < StandardError
+        attr_reader :response
+
+        def initialize(message, response)
+          super(message)
+          @response = response
+        end
+      end
 
       module Connection
         def get(path, options = {}, resource_key = nil)
@@ -24,19 +31,18 @@ module Finch
           response = self.class.send(http_method, path, options)
 
           if response.success?
-            parse_response(response.parsed_response, resource_key)
+            parse_response(response.parsed_response, response.headers, resource_key)
           else
-            raise APIError, response.parsed_response['message']
+            raise APIError.new(response.parsed_response['message'], response)
           end
         end
 
-        def parse_response(data, resource_key)
+        def parse_response(data, headers, resource_key)
           data = resource_key ? data[resource_key] : data
 
           case data
-          when Hash then Resource.new(data)
-          when Array then ResourceCollection.new(data)
-          # when Array then data.map { |item| item.is_a?(Hash) ? Resource.new(item) : item }
+          when Hash then Resource.new(data, headers)
+          when Array then ResourceCollection.new(data, headers)
           else raise(ArgumentError, "Unable to parse response - expected Hash or Array: #{data.inspect}")
           end
         end

--- a/lib/finch/client/api/connection.rb
+++ b/lib/finch/client/api/connection.rb
@@ -35,7 +35,8 @@ module Finch
 
           case data
           when Hash then Resource.new(data)
-          when Array then data.map { |item| item.is_a?(Hash) ? Resource.new(item) : item }
+          when Array then ResourceCollection.new(data)
+          # when Array then data.map { |item| item.is_a?(Hash) ? Resource.new(item) : item }
           else raise(ArgumentError, "Unable to parse response - expected Hash or Array: #{data.inspect}")
           end
         end

--- a/lib/finch/client/resource.rb
+++ b/lib/finch/client/resource.rb
@@ -3,11 +3,12 @@
 module Finch
   module Client
     class Resource
-      attr_reader :data, :raw_data
+      attr_reader :data, :raw_data, :headers
 
-      def initialize(data)
+      def initialize(data, headers = {})
         @raw_data = data
         @data = recursively_create_resources(data)
+        @headers = headers
       end
 
       def to_h

--- a/lib/finch/client/resource_collection.rb
+++ b/lib/finch/client/resource_collection.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Finch
+  module Client
+    class ResourceCollection
+      include Enumerable
+
+      attr_reader :data, :raw_data
+
+      def initialize(data)
+        @raw_data = data
+        @data = data.map { |item| item.is_a?(Hash) ? Resource.new(item) : item }
+      end
+
+      def each(&block)
+        data.each(&block)
+      end
+    end
+  end
+end

--- a/lib/finch/client/resource_collection.rb
+++ b/lib/finch/client/resource_collection.rb
@@ -5,13 +5,15 @@ module Finch
     class ResourceCollection
       include Enumerable
 
-      attr_reader :data, :raw_data
+      attr_reader :data, :raw_data, :headers
 
-      def initialize(data)
+      def initialize(data, headers = {})
         @raw_data = data
-        @data = data.map { |item| item.is_a?(Hash) ? Resource.new(item) : item }
+        @data = data.map { |item| item.is_a?(Hash) ? Resource.new(item, headers) : item }
+        @headers = headers
       end
 
+      # For satisfying the Enumerable interface
       def each(&block)
         data.each(&block)
       end

--- a/spec/finch/client/api/connection_spec.rb
+++ b/spec/finch/client/api/connection_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Finch::Client::API::Connection do
       stub_request(:get, 'https://example.com/test')
         .to_return(status: 200, body: [{ name: 'Finch' }].to_json)
 
-      expect(dummy_class.new.get('/test')).to be_a(Array)
+      expect(dummy_class.new.get('/test')).to be_a(Finch::Client::ResourceCollection)
       expect(dummy_class.new.get('/test').first).to be_a(Finch::Client::Resource)
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Finch::Client::API::Connection do
       stub_request(:post, 'https://example.com/test')
         .to_return(status: 201, body: [{ name: 'Finch' }].to_json)
 
-      expect(dummy_class.new.post('/test')).to be_a(Array)
+      expect(dummy_class.new.post('/test')).to be_a(Finch::Client::ResourceCollection)
       expect(dummy_class.new.post('/test').first).to be_a(Finch::Client::Resource)
     end
 
@@ -95,7 +95,7 @@ RSpec.describe Finch::Client::API::Connection do
       stub_request(:delete, 'https://example.com/test')
         .to_return(status: 201, body: [{ name: 'Finch' }].to_json)
 
-      expect(dummy_class.new.delete('/test')).to be_a(Array)
+      expect(dummy_class.new.delete('/test')).to be_a(Finch::Client::ResourceCollection)
       expect(dummy_class.new.delete('/test').first).to be_a(Finch::Client::Resource)
     end
 

--- a/spec/finch/client/api/organization_spec.rb
+++ b/spec/finch/client/api/organization_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Finch::Client::API::Organization do
 
       result = dummy_class.new.directory
 
-      expect(result).to be_a(Array)
+      expect(result).to be_a(Finch::Client::ResourceCollection)
       expect(result.first).to be_a(Finch::Client::Resource)
       expect(result.first.name).to eq('Finch')
     end
@@ -68,7 +68,7 @@ RSpec.describe Finch::Client::API::Organization do
 
       result = dummy_class.new.individual({ individual_id: '1' })
 
-      expect(result).to be_a(Array)
+      expect(result).to be_a(Finch::Client::ResourceCollection)
       expect(result.first).to be_a(Finch::Client::Resource)
       expect(result.first.name).to eq('Finch')
     end
@@ -98,7 +98,7 @@ RSpec.describe Finch::Client::API::Organization do
 
       result = dummy_class.new.employment({ individual_id: '1' })
 
-      expect(result).to be_a(Array)
+      expect(result).to be_a(Finch::Client::ResourceCollection)
       expect(result.first).to be_a(Finch::Client::Resource)
       expect(result.first.name).to eq('Finch')
     end

--- a/spec/finch/client/api/payroll_spec.rb
+++ b/spec/finch/client/api/payroll_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Finch::Client::API::Payroll do
 
       result = dummy_class.new.pay_statement({})
 
-      expect(result).to be_a(Array)
+      expect(result).to be_a(Finch::Client::ResourceCollection)
       expect(result.first).to be_a(Finch::Client::Resource)
       expect(result.first.name).to eq('Finch')
     end

--- a/spec/finch/client/resource_collection_spec.rb
+++ b/spec/finch/client/resource_collection_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Finch::Client::ResourceCollection do
+  before do
+    Finch::Client.configure do |config|
+      config.client_id = '12345'
+      config.client_secret = 'abcdef'
+      config.sandbox = false
+    end
+  end
+
+  describe '#initialize' do
+    it 'maps data into Resource instances' do
+      data = [{ 'name' => 'Finch', 'nested' => { 'id' => 1 } }]
+      resource = described_class.new(data)
+
+      expect(resource.data).to all(be_a(Finch::Client::Resource))
+    end
+  end
+
+  describe '#each' do
+    it 'yields each Resource' do
+      data = [{ 'name' => 'Finch', 'nested' => { 'id' => 1 } }]
+      resource = described_class.new(data)
+
+      expect { |block| resource.each(&block) }.to yield_control.exactly(1).times
+    end
+  end
+end

--- a/spec/finch/client/resource_collection_spec.rb
+++ b/spec/finch/client/resource_collection_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe Finch::Client::ResourceCollection do
 
       expect(resource.data).to all(be_a(Finch::Client::Resource))
     end
+
+    it 'allows you to set headers' do
+      resource = described_class.new({}, { 'X-Finch-Test' => 'test' })
+
+      expect(resource.headers['X-Finch-Test']).to eq('test')
+    end
+
+    it 'sets a default value for headers' do
+      resource = described_class.new({})
+
+      expect(resource.headers).to eq({})
+    end
   end
 
   describe '#each' do

--- a/spec/finch/client/resource_spec.rb
+++ b/spec/finch/client/resource_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Finch::Client::Resource do
       expect(resource.nested.first).to be_a(described_class)
       expect(resource.nested.last).to be_a(String)
     end
+
+    it 'allows you to set headers' do
+      resource = described_class.new({}, { 'X-Finch-Test' => 'test' })
+
+      expect(resource.headers['X-Finch-Test']).to eq('test')
+    end
+
+    it 'sets a default value for headers' do
+      resource = described_class.new({})
+
+      expect(resource.headers).to eq({})
+    end
   end
 
   describe '#to_h' do


### PR DESCRIPTION
Allows passthrough of request headers to allow logging of Finch request IDs as part of their onboarding checklist