### PR TITLE
Fixed bug with dynamic methods not being called as expected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    finch-client (0.1.0)
+    finch-client (0.1.2)
       httparty (>= 0.15.0)
 
 GEM

--- a/lib/finch/client/resource.rb
+++ b/lib/finch/client/resource.rb
@@ -16,7 +16,7 @@ module Finch
       end
 
       def method_missing(method_name, *arguments, &block)
-        data[method_name] || super
+        respond_to?(method_name) ? data[method_name] : super
       end
 
       def respond_to_missing?(method_name, include_private = false)

--- a/lib/finch/client/version.rb
+++ b/lib/finch/client/version.rb
@@ -2,6 +2,6 @@
 
 module Finch
   module Client
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/spec/finch/client/resource_spec.rb
+++ b/spec/finch/client/resource_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe Finch::Client::Resource do
       expect(resource.name).to eq(data['name'])
     end
 
+    it 'delegates to the data attribute even if its value is false' do
+      data = { 'is_active' => false }
+      resource = described_class.new(data)
+
+      expect(resource.is_active).to eq(data['is_active'])
+    end
+
     it 'raises an error if the data attribute does not respond to the method' do
       resource = described_class.new({})
 


### PR DESCRIPTION
The original implementation's logic would skip dynamic methods if the data attribute it would access was falsey.

The fix was to better check whether a data object responds to a method before trying to call it.  Now, we rely on the keys present in the hash which is more robust.