### PR TITLE
Increase HTTP timeout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    finch-client (0.1.2)
+    finch-client (0.1.3)
       httparty (>= 0.15.0)
 
 GEM

--- a/lib/finch/client/api.rb
+++ b/lib/finch/client/api.rb
@@ -19,6 +19,8 @@ module Finch
       include Management
       include Organization
 
+      default_timeout 180
+
       base_uri 'https://api.tryfinch.com'
       format :json
 

--- a/lib/finch/client/version.rb
+++ b/lib/finch/client/version.rb
@@ -2,6 +2,6 @@
 
 module Finch
   module Client
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end


### PR DESCRIPTION
Many Finch API calls end up coming close to the 60 second default timeout. This PR bumps the timeout to 180 seconds.